### PR TITLE
Ensure dates are set correctly on transition

### DIFF
--- a/src/update-trigger/index.ts
+++ b/src/update-trigger/index.ts
@@ -47,9 +47,6 @@ export async function run(event: UpdateEvent) {
     // Iterate over the items in the change log to verify whether or not a change of status
     // was part of this issue update event. We only want to perform any action if the status
     // has changed...
-    // console.log(
-    //   `Issue ${event.issue.key} was updated but neither state change nor re-parenting occurred`
-    // );
     return;
   }
 

--- a/src/update-trigger/index.ts
+++ b/src/update-trigger/index.ts
@@ -47,9 +47,9 @@ export async function run(event: UpdateEvent) {
     // Iterate over the items in the change log to verify whether or not a change of status
     // was part of this issue update event. We only want to perform any action if the status
     // has changed...
-    console.log(
-      `Issue ${event.issue.key} was updated but neither state change nor re-parenting occurred`
-    );
+    // console.log(
+    //   `Issue ${event.issue.key} was updated but neither state change nor re-parenting occurred`
+    // );
     return;
   }
 
@@ -129,6 +129,7 @@ export async function run(event: UpdateEvent) {
         issueIdOrKey,
         projectId: project.id,
         sprint: sprint && sprint[0],
+        preferredDateFields,
       });
     }
   } else {
@@ -139,7 +140,9 @@ export async function run(event: UpdateEvent) {
     const { to, toString, from, fromString } = parentChangeLogItem;
     if (from || fromString) {
       const parentId = (from as string) || (fromString as string);
-      console.log(`Updating previous parent: ${parentId}`);
+      console.log(
+        `Updating previous parent of ${issue.key} (which is ${parentId})`
+      );
       await updateParentStatus({
         parentId,
         project,
@@ -149,7 +152,7 @@ export async function run(event: UpdateEvent) {
     }
     if (to || toString) {
       const parentId = (to as string) || (toString as string);
-      console.log(`Updating new parent: ${parentId}`);
+      console.log(`Updating new parent of ${issue.key} (which is ${parentId})`);
       await updateParentStatus({
         parentId,
         project,
@@ -159,7 +162,9 @@ export async function run(event: UpdateEvent) {
     }
     return;
   } else if (statusTransition && parentRef) {
-    console.log(`Updating status of current parent: ${parentRef.key}`);
+    console.log(
+      `Updating status of current parent of ${issue.key} (which is ${parentRef.key})`
+    );
     await updateParentStatus({
       parentId: parentRef.id,
       project,

--- a/src/update-trigger/types.ts
+++ b/src/update-trigger/types.ts
@@ -315,7 +315,6 @@ export type GetMinMaxChildDates = (args: {
 }) => Promise<MinMaxDates | undefined>;
 
 export type GetParentMinMaxDateValues = (args: {
-  // parent: Issue;
   issueIdOrKey: string;
   projectId: string;
   preferredDateFields?: DateFields;

--- a/src/update-trigger/types.ts
+++ b/src/update-trigger/types.ts
@@ -242,6 +242,7 @@ export type UpdateIssueStartAndEndDatesForTransition = (args: {
   issueIdOrKey: string;
   projectId: string;
   sprint?: Sprint;
+  preferredDateFields?: DateFields;
 }) => Promise<void>;
 
 export type GetCustomField = (args: {
@@ -263,12 +264,14 @@ export type UpdateIssueStartAndEndDatesForSprintAssignment = (args: {
   preferredDateFields?: DateFields;
 }) => void;
 
-export type GetSprintStartAndEndDates = (args: {
-  sprint: Sprint | undefined;
-}) => {
+export type StartAndEndDates = {
   startDate: string | null;
   endDate: string | null;
 };
+
+export type GetSprintStartAndEndDates = (args: {
+  sprint: Sprint | undefined;
+}) => StartAndEndDates;
 
 export type DateFields = {
   startFieldId: string;
@@ -300,14 +303,30 @@ export type AddComment = (args: {
   comment: string;
 }) => void;
 
+export type MinMaxDates = {
+  earliestStartString: string | null;
+  latestEndString: string | null;
+};
+
 export type GetMinMaxChildDates = (args: {
   parentKey: string;
   startFieldId: string;
   endFieldId: string;
-}) => Promise<{
-  earliestStartString: string | undefined;
-  latestEndString: string | undefined;
-}>;
+}) => Promise<MinMaxDates | undefined>;
+
+export type GetParentMinMaxDateValues = (args: {
+  // parent: Issue;
+  issueIdOrKey: string;
+  projectId: string;
+  preferredDateFields?: DateFields;
+}) => Promise<MinMaxDates | undefined>;
+
+export type GetStartAndEndDatesToSet = (args: {
+  issueIdOrKey: string;
+  projectId: string;
+  preferredDateFields: DateFields;
+  sprint?: Sprint;
+}) => Promise<StartAndEndDates>;
 
 export type SetParentMinMaxDates = (args: {
   parent: Issue;

--- a/src/update-trigger/utils.ts
+++ b/src/update-trigger/utils.ts
@@ -539,13 +539,7 @@ export const updateIssueStartAndEndDatesForTransition: UpdateIssueStartAndEndDat
 
     const { startFieldId, startFieldName, endFieldId, endFieldName } =
       preferredDateFields;
-    // const { startDate, endDate } = getSprintStartAndEndDates({ sprint });
 
-    // TODO: The problem here is that when no sprint is set (i.e. for a parent) the dates are cleared
-    // We need to set sprint when appropriate, but when no sprint, fall back to min/max if supported
-
-    // What is precedence here?
-    // No children, use sprint, no sprint
     const { startDate, endDate } = await getStartAndEndDatesToSet({
       issueIdOrKey,
       projectId,


### PR DESCRIPTION
This PR ensures that when an issue is transitioned that there is an evaluation of the correct dates to set. The precedence is:

1. Min/Max child dates (if enabled and if children exist)
2. Sprint assignment (if issue is assigned to sprint)
3. Original transition (e.g. set today as start date if moved to in progress, set end date as today if moved to done)