### PR TITLE
Improve min max handling

### DIFF
--- a/src/update-trigger/types.ts
+++ b/src/update-trigger/types.ts
@@ -284,7 +284,7 @@ export type GetPreferredDateFields = (args: {}) => Promise<
   DateFields | undefined
 >;
 
-export type DatesToSet = "BOTH" | "START" | "END";
+export type DatesToSet = "NONE" | "BOTH" | "START" | "END";
 
 export type UpdateDatesWithComment = (args: {
   issueIdOrKey: string;
@@ -306,6 +306,7 @@ export type AddComment = (args: {
 export type MinMaxDates = {
   earliestStartString: string | null;
   latestEndString: string | null;
+  hasIncompleteChildren: boolean;
 };
 
 export type GetMinMaxChildDates = (args: {


### PR DESCRIPTION
This PR improve the handling of min/max date setting for parents based on their children.

This change ensures that a parents end date isn't reduced when it still has unresolved child issues. The parents end date can still be pushed out if incomplete children have extended dates, but it cannot be reduced.

This means that when a parent end date is set before the story breakdown is complete or before all children dates have been set, that it won't be inadvertently shortened and disrupt plans.